### PR TITLE
Add Pinned Object Heap Size support in a backwards compatible way

### DIFF
--- a/CoreCLRProfiler/managed/Program.cs
+++ b/CoreCLRProfiler/managed/Program.cs
@@ -91,6 +91,7 @@ namespace Microsoft.BPerf.BuildTools
             CreatePInvokeImpl(metadataBuilder, "GetGen1HeapSize", moduleReferenceHandle, ref methodIndex);
             CreatePInvokeImpl(metadataBuilder, "GetGen2HeapSize", moduleReferenceHandle, ref methodIndex);
             CreatePInvokeImpl(metadataBuilder, "GetGen3HeapSize", moduleReferenceHandle, ref methodIndex);
+            CreatePInvokeImpl(metadataBuilder, "GetPinnedObjectHeapSize", moduleReferenceHandle, ref methodIndex);
             CreatePInvokeImpl(metadataBuilder, "GetFrozenHeapSize", moduleReferenceHandle, ref methodIndex);
             CreatePInvokeImpl(metadataBuilder, "GetNumberOfGCSegments", moduleReferenceHandle, ref methodIndex);
             CreatePInvokeImpl(metadataBuilder, "GetNumberOfFrozenSegments", moduleReferenceHandle, ref methodIndex);

--- a/CoreCLRProfiler/native/BPerfProfilerCallback.cpp
+++ b/CoreCLRProfiler/native/BPerfProfilerCallback.cpp
@@ -65,6 +65,7 @@ BPerfProfilerCallback::BPerfProfilerCallback()
     this->gen1HeapSize = 0;
     this->gen2HeapSize = 0;
     this->gen3HeapSize = 0; // LOH
+    this->pinnedObjectHeapSize = 0;
     this->frozenHeapSize = 0;
 
     this->numberOfGCSegments = 0;
@@ -617,7 +618,7 @@ HRESULT STDMETHODCALLTYPE BPerfProfilerCallback::SurvivingReferences(ULONG cSurv
 
 HRESULT STDMETHODCALLTYPE BPerfProfilerCallback::GarbageCollectionFinished()
 {
-    size_t generationSizes[4] = { 0, 0, 0, 0 };
+    size_t generationSizes[5] = { 0, 0, 0, 0, 0 };
     size_t frozenSegmentsSize = 0;
 
     ULONG cObjectRanges = 0;
@@ -649,9 +650,10 @@ HRESULT STDMETHODCALLTYPE BPerfProfilerCallback::GarbageCollectionFinished()
     this->gen1HeapSize = generationSizes[COR_PRF_GC_GEN_1];
     this->gen2HeapSize = generationSizes[COR_PRF_GC_GEN_2];
     this->gen3HeapSize = generationSizes[COR_PRF_GC_LARGE_OBJECT_HEAP];
+    this->pinnedObjectHeapSize = generationSizes[COR_PRF_GC_PINNED_OBJECT_HEAP];
     this->frozenHeapSize = frozenSegmentsSize;
 
-    this->totalNumberOfBytesInAllHeaps = generationSizes[COR_PRF_GC_GEN_0] + generationSizes[COR_PRF_GC_GEN_1] + generationSizes[COR_PRF_GC_GEN_2] + generationSizes[COR_PRF_GC_LARGE_OBJECT_HEAP] + frozenSegmentsSize;
+    this->totalNumberOfBytesInAllHeaps = generationSizes[COR_PRF_GC_GEN_0] + generationSizes[COR_PRF_GC_GEN_1] + generationSizes[COR_PRF_GC_GEN_2] + generationSizes[COR_PRF_GC_LARGE_OBJECT_HEAP] + generationSizes[COR_PRF_GC_PINNED_OBJECT_HEAP] + frozenSegmentsSize;
 
     return S_OK;
 }
@@ -952,6 +954,11 @@ size_t BPerfProfilerCallback::GetGen2HeapSize() const
 size_t BPerfProfilerCallback::GetGen3HeapSize() const
 {
     return this->gen3HeapSize;
+}
+
+size_t BPerfProfilerCallback::GetPinnedObjectHeapSize() const
+{
+    return this->pinnedObjectHeapSize;
 }
 
 size_t BPerfProfilerCallback::GetFrozenHeapSize() const

--- a/CoreCLRProfiler/native/BPerfProfilerCallback.h
+++ b/CoreCLRProfiler/native/BPerfProfilerCallback.h
@@ -172,6 +172,7 @@ public:
     size_t GetGen1HeapSize() const;
     size_t GetGen2HeapSize() const;
     size_t GetGen3HeapSize() const;
+    size_t GetPinnedObjectHeapSize() const;
     size_t GetFrozenHeapSize() const;
     size_t GetNumberOfGCSegments() const;
     size_t GetNumberOfFrozenSegments() const;
@@ -278,6 +279,7 @@ private:
     std::atomic<size_t> gen1HeapSize;
     std::atomic<size_t> gen2HeapSize;
     std::atomic<size_t> gen3HeapSize; // LOH
+    std::atomic<size_t> pinnedObjectHeapSize;
     std::atomic<size_t> frozenHeapSize; // Frozen
 
     std::atomic<size_t> numberOfGCSegments;

--- a/CoreCLRProfiler/native/exports.def
+++ b/CoreCLRProfiler/native/exports.def
@@ -37,6 +37,7 @@ EXPORTS
     GetGen1HeapSize
     GetGen2HeapSize
     GetGen3HeapSize
+    GetPinnedObjectHeapSize
     GetFrozenHeapSize
     GetNumberOfGCSegments
     GetNumberOfFrozenSegments


### PR DESCRIPTION
.NET 5 supports POH, but we can treat it as 0 for NET Core 3.1 so it's backwards compatible. The API will be available in the regular BPerf managed API but will always be 0 for 3.1, which is not that bad to keep our code simple.