### PR TITLE
Fix Stackoverflow

### DIFF
--- a/CoreCLRProfiler/native/BPerfProfilerCallback.h
+++ b/CoreCLRProfiler/native/BPerfProfilerCallback.h
@@ -178,8 +178,8 @@ public:
     size_t GetNumberOfFrozenSegments() const;
 
     /* Control APIs */
-    bool EnableObjectAllocationMonitoring();
-    bool DisableObjectAllocationMonitoring();
+    bool EnableObjectAllocationMonitoring() const;
+    bool DisableObjectAllocationMonitoring() const;
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override
     {

--- a/CoreCLRProfiler/native/PrettyPrintSig.cpp
+++ b/CoreCLRProfiler/native/PrettyPrintSig.cpp
@@ -8,7 +8,6 @@
 //
 //*****************************************************************************
 
-#define _alloca alloca
 #include "profiler_pal.h"
 #include "corhlpr.h"
 #include "CQuickBytes.h"

--- a/CoreCLRProfiler/native/profiler_pal.h
+++ b/CoreCLRProfiler/native/profiler_pal.h
@@ -2,6 +2,7 @@
 
 #ifndef _WINDOWS
 
+#define _alloca alloca
 #define PAL_STDCPP_COMPAT
 #define UNICODE
 #define FEATURE_PAL


### PR DESCRIPTION
* Changes from this->corProfilerInfo to tmp are just so we're operating on the same pointer.
* The bug is in `JITCachedFunctionSearchFinished` where there a crash with the following stack in Bing production with 5.0 bits

```
[0x0]   ntdll!NtWaitForAlertByThreadId + 0x14   
[0x1]   ntdll!RtlAcquireSRWLockExclusive + 0x131   
[0x2]   ntdll!RtlpCallVectoredHandlers + 0x122   
[0x3]   ntdll!RtlDispatchException + 0x69   
[0x4]   ntdll!KiUserExceptionDispatch + 0x2e   
[0x5]   Microsoft_BPerf_CoreCLRProfiler!BPerfProfilerCallback::JITCachedFunctionSearchFinished + 0x32   
[0x6]   coreclr!EEToProfInterfaceImpl::JITCachedFunctionSearchFinished + 0x71   
[0x7]   coreclr!ReadyToRunInfo::GetEntryPoint + 0x9ba   
[0x8]   coreclr!MethodDesc::GetPrecompiledR2RCode + 0x47   
[0x9]   coreclr!MethodDesc::GetPrecompiledCode + 0x1a   
[0xa]   coreclr!MethodDesc::PrepareILBasedCode + 0xf1   
[0xb]   coreclr!MethodDesc::PrepareCode + 0x12   
[0xc]   coreclr!MethodDesc::PrepareInitialCode + 0x4e   
[0xd]   coreclr!MethodDesc::DoPrestub + 0x38c   
[0xe]   coreclr!PreStubWorker + 0x462   
[0xf]   coreclr!ThePreStub + 0x55   
[0x10]   coreclr!CallDescrWorkerInternal + 0x83   
[0x11]   coreclr!DispatchCallDebuggerWrapper + 0x1c   
[0x12]   coreclr!DispatchCallSimple + 0x60   
[0x13]   coreclr!CallDefaultConstructor + 0xaf   
[0x14]   coreclr!EEException::CreateThrowable + 0xcc   
[0x15]   coreclr!CreateCOMPlusExceptionObject + 0x202   
[0x16]   coreclr!ExceptionTracker::CreateThrowable + 0x15c1d6   
[0x17]   coreclr!ExceptionTracker::GetOrCreateTracker + 0x19a   
[0x18]   coreclr!ProcessCLRException + 0x235   
[0x19]   ntdll!RtlpExecuteHandlerForException + 0xf   
[0x1a]   ntdll!RtlDispatchException + 0x40f   
[0x1b]   ntdll!KiUserExceptionDispatch + 0x2e   
[0x1c]   Microsoft_BPerf_CoreCLRProfiler!BPerfProfilerCallback::JITCachedFunctionSearchFinished + 0x32   
[0x1d]   coreclr!EEToProfInterfaceImpl::JITCachedFunctionSearchFinished + 0x71   
[0x1e]   coreclr!ReadyToRunInfo::GetEntryPoint + 0x9ba   
[0x1f]   coreclr!MethodDesc::GetPrecompiledR2RCode + 0x47   
[0x20]   coreclr!MethodDesc::GetPrecompiledCode + 0x1a   
[0x21]   coreclr!MethodDesc::PrepareILBasedCode + 0xf1   
[0x22]   coreclr!MethodDesc::PrepareCode + 0x12   
[0x23]   coreclr!MethodDesc::PrepareInitialCode + 0x4e   
[0x24]   coreclr!MethodDesc::DoPrestub + 0x38c   
[0x25]   coreclr!PreStubWorker + 0x462   
[0x26]   coreclr!ThePreStub + 0x55   
[0x27]   coreclr!CallDescrWorkerInternal + 0x83   
[0x28]   coreclr!DispatchCallDebuggerWrapper + 0x1c   
[0x29]   coreclr!DispatchCallSimple + 0x60   
[0x2a]   coreclr!CallDefaultConstructor + 0xaf   
[0x2b]   coreclr!EEException::CreateThrowable + 0xcc   
[0x2c]   coreclr!CreateCOMPlusExceptionObject + 0x202   
[0x2d]   coreclr!ExceptionTracker::CreateThrowable + 0x15c1d6   
[0x2e]   coreclr!ExceptionTracker::GetOrCreateTracker + 0x19a   
[0x2f]   coreclr!ProcessCLRException + 0x235   
[0x30]   ntdll!RtlpExecuteHandlerForException + 0xf   
[0x31]   ntdll!RtlDispatchException + 0x40f   
[0x32]   ntdll!KiUserExceptionDispatch + 0x2e   
[0x33]   Microsoft_BPerf_CoreCLRProfiler!BPerfProfilerCallback::JITCachedFunctionSearchFinished + 0x32   
[0x34]   coreclr!EEToProfInterfaceImpl::JITCachedFunctionSearchFinished + 0x71   
[0x35]   coreclr!ReadyToRunInfo::GetEntryPoint + 0x9ba   
[0x36]   coreclr!MethodDesc::GetPrecompiledR2RCode + 0x47   
[0x37]   coreclr!MethodDesc::GetPrecompiledCode + 0x1a   
[0x38]   coreclr!MethodDesc::PrepareILBasedCode + 0xf1   
[0x39]   coreclr!MethodDesc::PrepareCode + 0x12   
[0x3a]   coreclr!MethodDesc::PrepareInitialCode + 0x4e   
[0x3b]   coreclr!MethodDesc::DoPrestub + 0x38c   
[0x3c]   coreclr!PreStubWorker + 0x462   
[0x3d]   coreclr!ThePreStub + 0x55   
[0x3e]   coreclr!CallDescrWorkerInternal + 0x83   
[0x3f]   coreclr!DispatchCallDebuggerWrapper + 0x1c   
[0x40]   coreclr!DispatchCallSimple + 0x60   
[0x41]   coreclr!CallDefaultConstructor + 0xaf   
[0x42]   coreclr!EEException::CreateThrowable + 0xcc   
[0x43]   coreclr!CreateCOMPlusExceptionObject + 0x202   
[0x44]   coreclr!ExceptionTracker::CreateThrowable + 0x15c1d6   
[0x45]   coreclr!ExceptionTracker::GetOrCreateTracker + 0x19a   
[0x46]   coreclr!ProcessCLRException + 0x235   
[0x47]   ntdll!RtlpExecuteHandlerForException + 0xf   
[0x48]   ntdll!RtlDispatchException + 0x40f   
[0x49]   ntdll!KiUserExceptionDispatch + 0x2e   
[0x4a]   Microsoft_BPerf_CoreCLRProfiler!BPerfProfilerCallback::JITCachedFunctionSearchFinished + 0x32   
[0x4b]   coreclr!EEToProfInterfaceImpl::JITCachedFunctionSearchFinished + 0x71   
[0x4c]   coreclr!ReadyToRunInfo::GetEntryPoint + 0x9ba   
[0x4d]   coreclr!MethodDesc::GetPrecompiledR2RCode + 0x47   
[0x4e]   coreclr!MethodDesc::GetPrecompiledCode + 0x1a   
[0x4f]   coreclr!MethodDesc::PrepareILBasedCode + 0xf1   
[0x50]   coreclr!MethodDesc::PrepareCode + 0x12   
[0x51]   coreclr!MethodDesc::PrepareInitialCode + 0x4e   
[0x52]   coreclr!MethodDesc::DoPrestub + 0x38c   
[0x53]   coreclr!PreStubWorker + 0x462   
[0x54]   coreclr!ThePreStub + 0x55   
[0x55]   coreclr!CallDescrWorkerInternal + 0x83   
[0x56]   coreclr!DispatchCallDebuggerWrapper + 0x1c   
[0x57]   coreclr!DispatchCallSimple + 0x60   
[0x58]   coreclr!CallDefaultConstructor + 0xaf   
[0x59]   coreclr!EEException::CreateThrowable + 0xcc   
[0x5a]   coreclr!CreateCOMPlusExceptionObject + 0x202   
[0x5b]   coreclr!ExceptionTracker::CreateThrowable + 0x15c1d6   
[0x5c]   coreclr!ExceptionTracker::GetOrCreateTracker + 0x19a   
[0x5d]   coreclr!ProcessCLRException + 0x235   
[0x5e]   ntdll!RtlpExecuteHandlerForException + 0xf   
[0x5f]   ntdll!RtlDispatchException + 0x40f   
[0x60]   ntdll!KiUserExceptionDispatch + 0x2e   
[0x61]   Microsoft_BPerf_CoreCLRProfiler!BPerfProfilerCallback::JITCachedFunctionSearchFinished + 0x32   
[0x62]   coreclr!EEToProfInterfaceImpl::JITCachedFunctionSearchFinished + 0x71   
[0x63]   coreclr!ReadyToRunInfo::GetEntryPoint + 0x9ba
```

The problem is that it is trying to restore `System.AccessViolationException..ctor()` because of an initial AV which then calls `JITCachedFunctionSearchFinished ` which throws an AV because `this->corProfilerInfo` is null somehow (that remains a mystery) which then tries to restore `System.AccessViolationException..ctor()`, which then calls `JITCachedFunctionSearchFinished`, so on and so forth ...